### PR TITLE
Gro 11 beneficiary validation fix

### DIFF
--- a/EscrowToken.sol
+++ b/EscrowToken.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 
 /// @title EscrowToken - The utility token for the iEscrow ecosystem
 /// @notice Standard ERC20 with 18 decimals, ERC20Permit for gasless approvals, and burnable tokens
@@ -212,7 +213,7 @@ contract EscrowToken is ERC20, ERC20Permit, ERC20Burnable, Ownable, ReentrancyGu
         uint256 balance = address(this).balance;
         require(balance > 0, "No ETH to withdraw");
         
-        to.transfer(balance);
+        Address.sendValue(payable(to), balance);
         emit EmergencyWithdrawal(address(0), to, balance);
     }
     

--- a/MultiTokenPresale.sol
+++ b/MultiTokenPresale.sol
@@ -362,8 +362,11 @@ contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
         bool authorized = authorizer.authorize(voucher, signature, token, usdAmount);
         require(authorized, "Voucher authorization failed");
         
-        // Transfer tokens (SafeERC20 handles USDT compatibility)
-        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        // Transfer tokens with deflationary token compatibility check
+        uint256 beforeBalance = IERC20(token).balanceOf(address(this));
+        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        uint256 received = IERC20(token).balanceOf(address(this)) - beforeBalance;
+        require(received == amount, "Deflationary token not supported");
         
         uint256 tokenAmount = _calculateTokenAmountForVoucher(token, amount, beneficiary, usdAmount);
         _processVoucherPurchase(beneficiary, token, amount, tokenAmount, voucher);

--- a/MultiTokenPresale.sol
+++ b/MultiTokenPresale.sol
@@ -9,9 +9,16 @@ import "@openzeppelin/contracts/utils/Pausable.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "./Authorizer.sol";
 
+/**
+ * @title MultiTokenPresale
+ * @notice Advanced presale contract with KYC voucher authorization system
+ * @dev Implements strict beneficiary validation through cryptographic vouchers:
+ * - UnityPresaleV2.sol: Enforces beneficiary == msg.sender (no delegated purchases)
+ * - MultiTokenPresale.sol: Allows delegated purchases ONLY through authorized vouchers
+ * - This ensures consistent validation across the presale system
+ */
 contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
-    
     // Token price structure
     struct TokenPrice {
         uint256 priceUSD;        // Price in USD (8 decimals)
@@ -286,8 +293,12 @@ contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
     
     // ============ VOUCHER-BASED PURCHASE FUNCTIONS ============
     
-    /// @notice Purchase with native currency using voucher authorization
-    /// @param beneficiary Address that will receive the tokens
+    /// @notice Purchase with native currency using voucher authorization (KYC-AUTHORIZED DELEGATED PURCHASES)
+    /// @dev BENEFICIARY VALIDATION POLICY: Allows delegated purchases ONLY through authorized vouchers
+    /// - voucher.buyer must equal msg.sender (only voucher holder can use it)
+    /// - voucher.beneficiary must equal beneficiary parameter (specified in voucher)
+    /// - This enables KYC-verified delegated purchases while preventing unauthorized ones
+    /// @param beneficiary Address that will receive the tokens (must match voucher.beneficiary)
     /// @param voucher Purchase voucher containing authorization details
     /// @param signature EIP-712 signature of the voucher
     function buyWithNativeVoucher(
@@ -327,10 +338,14 @@ contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
         _processVoucherPurchase(beneficiary, NATIVE_ADDRESS, paymentAmount, tokenAmount, voucher);
     }
     
-    /// @notice Purchase with ERC20 tokens using voucher authorization
+    /// @notice Purchase with ERC20 tokens using voucher authorization (KYC-AUTHORIZED DELEGATED PURCHASES)
+    /// @dev BENEFICIARY VALIDATION POLICY: Allows delegated purchases ONLY through authorized vouchers
+    /// - voucher.buyer must equal msg.sender (only voucher holder can use it)
+    /// - voucher.beneficiary must equal beneficiary parameter (specified in voucher)
+    /// - This enables KYC-verified delegated purchases while preventing unauthorized ones
     /// @param token Payment token address
     /// @param amount Payment token amount
-    /// @param beneficiary Address that will receive the tokens
+    /// @param beneficiary Address that will receive the tokens (must match voucher.beneficiary)
     /// @param voucher Purchase voucher containing authorization details
     /// @param signature EIP-712 signature of the voucher
     function buyWithTokenVoucher(

--- a/MultiTokenPresale.sol
+++ b/MultiTokenPresale.sol
@@ -467,6 +467,9 @@ contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
     
     // Check if presale should auto-end
     function _checkAutoEndConditions() internal {
+        // Prevent overwrites if already ended
+        if (presaleEnded) return;
+
         // End if all tokens sold
         if (totalTokensMinted >= maxTokensToMint) {
             presaleEnded = true;

--- a/MultiTokenPresale.sol
+++ b/MultiTokenPresale.sol
@@ -6,13 +6,11 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 import "./Authorizer.sol";
 
 contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
-    
-    // Gas buffer for native currency purchases
-    uint256 public gasBuffer = 0.0005 ether; // Default 0.0005 ETH buffer
     
     // Token price structure
     struct TokenPrice {
@@ -30,6 +28,9 @@ contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
     // Authorizer integration for voucher-based purchases
     Authorizer public authorizer;
     bool public voucherSystemEnabled = false; // Disabled by default for compatibility
+    
+    // Gas buffer for native currency purchases
+    uint256 public gasBuffer = 0.0005 ether; // Default 0.0005 ETH buffer
     
     // Price management
     mapping(address => TokenPrice) public tokenPrices;
@@ -525,7 +526,7 @@ contract MultiTokenPresale is Ownable, ReentrancyGuard, Pausable {
     function withdrawNative() external onlyOwner {
         uint256 balance = address(this).balance;
         require(balance > 0, "No native currency to withdraw");
-        payable(owner()).transfer(balance);
+        Address.sendValue(payable(owner()), balance);
     }
     
     function withdrawToken(address token) external onlyOwner {

--- a/UnityStakeV5.sol
+++ b/UnityStakeV5.sol
@@ -982,10 +982,14 @@ contract TokenStaking is Ownable, ReentrancyGuard {
 
         _totalStakedTokens += _amount;
 
+        // Transfer tokens with deflationary token compatibility check
+        uint256 beforeBalance = _token.balanceOf(address(this));
         require(
             _token.transferFrom(msg.sender, address(this), _amount * 1e18),
             "TokenStaking: failed to transfer tokens"
         );
+        uint256 received = _token.balanceOf(address(this)) - beforeBalance;
+        require(received == _amount * 1e18, "TokenStaking: deflationary token not supported");
         emit Stake(user_, _amount);
 
 //*************************************************

--- a/test/MultiTokenPresale.t.sol
+++ b/test/MultiTokenPresale.t.sol
@@ -569,14 +569,121 @@ contract MultiTokenPresaleTest is Test {
         presale.buyWithTokenVoucher(address(0), 0.01 ether, buyer1, voucher, signature);
     }
     
-    // ========== GRO-05 PRESALE END TIME PROTECTION TESTS ==========
+    // ========== GRO-04 PER-USER PURCHASE LIMIT TESTS ==========
 
+    function testPerUserLimitEnforcedNativeCurrency() public {
+        _startPresale();
+
+        // Calculate maximum ETH purchase for $10,000 limit at $4200/ETH = ~2.38 ETH
+        // Use explicit calculation to avoid rational numbers: (10000 * 1e18) / 4200
+        uint256 maxEthAmount = 2380952380952380952; // ~2.38 ETH in wei
+
+        // Should succeed at exactly the limit (allowing for rounding differences)
+        Authorizer.Voucher memory voucher1 = _createVoucher(buyer1, buyer1, address(0), 0);
+        bytes memory signature1 = _signVoucher(voucher1);
+
+        vm.prank(buyer1);
+        presale.buyWithNativeVoucher{value: maxEthAmount}(buyer1, voucher1, signature1);
+        
+        assertTrue(presale.totalPurchased(buyer1) > 0, "Purchase should succeed at limit");
+    }
+    
+    function testPerUserLimitExceeded() public {
+        _startPresale();
+
+        // Try to purchase more than $10,000 limit (this should fail)
+        // Use an amount that exceeds per-user cap but fits within voucher limit
+        uint256 excessEthAmount = 2380952380952380952; // ~2.38 ETH = exactly at per-user limit
+
+        // First make a purchase at the limit
+        Authorizer.Voucher memory voucher1 = _createVoucher(buyer1, buyer1, address(0), 0);
+        bytes memory signature1 = _signVoucher(voucher1);
+
+        vm.prank(buyer1);
+        presale.buyWithNativeVoucher{value: excessEthAmount}(buyer1, voucher1, signature1);
+
+        // Now try to make another purchase - this should exceed the per-user cap
+        Authorizer.Voucher memory voucher2 = _createVoucher(buyer1, buyer1, address(0), 1);
+        bytes memory signature2 = _signVoucher(voucher2);
+
+        vm.expectRevert("Exceeds per-user cap");
+        vm.prank(buyer1);
+        presale.buyWithNativeVoucher{value: 0.01 ether}(buyer1, voucher2, signature2);
+    }
+    
+    function testPerUserLimitWithTokens() public {
+        _startPresale();
+        
+        // Calculate maximum USDC purchase for $10,000 limit = 10,000 USDC
+        uint256 maxUsdcAmount = 10000 * 1e6; // $10,000 USDC
+        
+        // Should succeed at exactly the limit
+        vm.startPrank(buyer1);
+        mockUSDC.approve(address(presale), maxUsdcAmount);
+        
+        Authorizer.Voucher memory voucher = _createVoucher(buyer1, buyer1, address(mockUSDC), 0);
+        bytes memory signature = _signVoucher(voucher);
+        
+        presale.buyWithTokenVoucher(address(mockUSDC), maxUsdcAmount, buyer1, voucher, signature);
+        vm.stopPrank();
+        
+        assertTrue(presale.totalPurchased(buyer1) > 0, "Token purchase should succeed at limit");
+    }
+    
+    function testMultiplePurchasesAccumulateCorrectly() public {
+        _startPresale();
+        
+        // Make first purchase: $3,000
+        uint256 firstAmount = 3000 * 1e6;
+        vm.startPrank(buyer1);
+        mockUSDC.approve(address(presale), firstAmount);
+        
+        Authorizer.Voucher memory voucher1 = _createVoucher(buyer1, buyer1, address(mockUSDC), 0);
+        presale.buyWithTokenVoucher(address(mockUSDC), firstAmount, buyer1, voucher1, _signVoucher(voucher1));
+        vm.stopPrank();
+        
+        uint256 tokensAfterFirst = presale.totalPurchased(buyer1);
+        
+        // Make second purchase: $3,000 (total should be $6,000)
+        uint256 secondAmount = 3000 * 1e6;
+        vm.startPrank(buyer1);
+        mockUSDC.approve(address(presale), secondAmount);
+        
+        Authorizer.Voucher memory voucher2 = _createVoucher(buyer1, buyer1, address(mockUSDC), 1);
+        presale.buyWithTokenVoucher(address(mockUSDC), secondAmount, buyer1, voucher2, _signVoucher(voucher2));
+        vm.stopPrank();
+        
+        uint256 tokensAfterSecond = presale.totalPurchased(buyer1);
+        assertTrue(tokensAfterSecond > tokensAfterFirst, "Tokens should accumulate");
+        
+        // Third purchase should exceed limit ($6,000 + $5,000 = $11,000 > $10,000)
+        uint256 thirdAmount = 5000 * 1e6;
+        vm.startPrank(buyer1);
+        mockUSDC.approve(address(presale), thirdAmount);
+
+        // Create voucher with higher limit to test per-user cap instead of voucher limit
+        Authorizer.Voucher memory voucher3 = Authorizer.Voucher({
+            buyer: buyer1,
+            beneficiary: buyer1,
+            paymentToken: address(mockUSDC),
+            usdLimit: 15000 * 1e8, // $15,000 limit to exceed per-user cap of $10,000
+            nonce: 2,
+            deadline: type(uint256).max,
+            presale: address(presale)
+        });
+        bytes memory signature3 = _signVoucher(voucher3);
+
+        vm.expectRevert("Exceeds per-user cap");
+        presale.buyWithTokenVoucher(address(mockUSDC), thirdAmount, buyer1, voucher3, signature3);
+        vm.stopPrank();
+    }
+    
     /// @notice Test that presaleEndTime is not overwritten after presale ends
     /// @dev This test demonstrates the GRO-05 fix prevents repeated overwrites of presaleEndTime
     function testPresaleEndTimeNotOverwrittenAfterEnd() public {
         _startPresale();
         uint256 startTime = presale.presaleStartTime();
-
+        
         // Verify presale is active initially
         assertTrue(presale.isPresaleActive());
         assertFalse(presale.presaleEnded());
@@ -724,3 +831,4 @@ contract MultiTokenPresaleTest is Test {
         vm.stopPrank();
     }
 }
+


### PR DESCRIPTION
GRO-11 – Inconsistent Beneficiary Validation

Apply a unified policy:
Either enforce beneficiary == msg.sender for all purchases,
or explicitly allow delegated purchases but document it.

